### PR TITLE
get model specs green

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,6 +78,13 @@ RSpec/InstanceVariable:
 RSpec/NamedSubject:
   Enabled: false
 
+RSpec/LetSetup:
+  Exclude:
+    - "spec/models/content_block_spec.rb"
+    - "spec/models/account_spec.rb"
+    - "spec/models/user_spec.rb"
+    - "spec/models/role_spec.rb"
+
 RSpec/DescribeClass:
   Exclude:
     - "spec/requests/**/*"

--- a/spec/models/content_block_spec.rb
+++ b/spec/models/content_block_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe ContentBlock, type: :model do
   describe '.announcement_text' do
     subject { described_class.for(:announcement).value }
 
-    before(:announcement) do
+    let!(:announcement) do
       create(:content_block,
              name: ContentBlock::NAME_REGISTRY[:announcement],
              value: '<h1>Announcement Text</h1>')
@@ -57,7 +57,7 @@ RSpec.describe ContentBlock, type: :model do
   describe '.marketing_text' do
     subject { described_class.for(:marketing).value }
 
-    before(:marketing) do
+    let!(:marketing) do
       create(:content_block,
              name: ContentBlock::NAME_REGISTRY[:marketing],
              value: '<h1>Marketing Text</h1>')
@@ -121,7 +121,7 @@ RSpec.describe ContentBlock, type: :model do
   describe '.home_text' do
     subject { described_class.for(:home_text).value }
 
-    before(:home_text) do
+    let!(:home_text) do
       create(:content_block,
              name: ContentBlock::NAME_REGISTRY[:home_text],
              value: '<h1>Home Page Text</h1>')


### PR DESCRIPTION
Rubocop recommends not using the Let! block, however tests copied over from Hyrax are using them. Reverted test back to use the Let! block. Added the model specs that use it to the rubocop.yml file
